### PR TITLE
Updated INT pre-2.0

### DIFF
--- a/telemetry/specs/INT.mdk
+++ b/telemetry/specs/INT.mdk
@@ -174,7 +174,7 @@ packets “observed” while being forwarded.
 
 Some examples of traffic sink behavior are described below:
 
-* OAM – the traffic sink might simply collect the encoded network state, then
+* OAM – the traffic sink[^Transit] might simply collect the encoded network state, then
 export that state to an external controller.  This export could be in a raw
 format, or could be combined with basic processing (such as compression,
 deduplication, truncation).
@@ -187,7 +187,7 @@ of these types of feedback loops).
 
 * Network Event Detection - If the collected path state indicates a condition
 that requires immediate attention or resolution (such as severe congestion or
-violation of certain data-plane invariances), the traffic sinks could generate
+violation of certain data-plane invariances), the traffic sinks[^Transit] could generate
 immediate actions to respond to the network events, forming a feedback control
 loop either in a centralized or a fully decentralized fashion (a la TCP).
 
@@ -208,6 +208,7 @@ of Little Minions paper [^Minions].
 [^CLOVE]: CLOVE: Congestion-Aware Load Balancing at the Virtual Edge, ACM CoNEXT 2017
 [^Minions]: Millions of Little Minions: Using Packets for Low Latency Network Programming and Visibility, ACM SIGCOMM 2014.
 [^Postcard]: I Know What Your Packet Did Last Hop: Using Packet Histories to Troubleshoot Networks, USENIX NSDI 2014.
+[^Transit]: WHile this will be commonly done by Sink nodes, Transit nodes may also generate OAM's or carry out Network Event Detection 
 
 # Terminology
 
@@ -276,9 +277,9 @@ INT operations based on the following criteria:
 The different modes of operations are described in detail below, and summarized
 in Figure [fig-int-modes].
 
-## INT Applied to Real Data Packets
+## INT Application Modes 
 
-In this category, the original data packets are monitored and may be modified
+Original data packets are monitored and may be modified
 to carry INT instructions and metadata.
 There are three variations based on the level of packet modifications.
 
@@ -308,25 +309,27 @@ at the monitoring system to collate reports from multiple devices.
 
 ## INT Applied to Synthetic Traffic
 
-In this category, INT Source devices generate synthetic traffic either by
-clonning the original data packets or by generating special probe packets.
-INT is applied to the synthetic traffic.
+INT Source devices may generate INT-marked synthetic traffic either by
+cloning  original data packets or by generating special probe packets.
+INT is applied to this traffic by transit nodes in exactly the same way 
+as all traffic. 
 
-The XD mode doesn't make sense for synthetic traffic. The MX mode is
-technically possible but doesn't add much value. Hence we define two MD modes
-as follows.
 
-* INT-CLONE-MD (eMbed Data): INT Source devices create extra traffic through
-cloning the original packets and then embedding the INT instructions and metadata into
-the clones only. INT Transit devices accumulate metadata only on the clones,
-INT Sink devices may send telemetry reports before discarding the clones.
-Compared to INT-MD, INT-CLONE-MD produces extra traffic
-and may not capture actual network state that the orignal packets experience, while
-this mode avoids direct modification on the original data packets.
-This mode is similar to IFA [^IFA].
+The only difference between live traffic and Synthetic traffic is that 
+INT-Sink nodes may need to discard synthetic traffic after extracting 
+the collected INT data as opposed to forwading the traffic. This is 
+indicated by using the 'C' bit of the INT-Header to mark relavant packets
+as being Copies/Clones, to be discarded at the INT-Sink.  
 
-* INT-PROBE-MD (eMbed Data): similar to INT-CLONE-MD, but INT is applied to
-special probe packets instead of clone packets.
+All INT modes may be used on these Syntehtic/probe packets, as decided by the INT-Source node. 
+Specifically the **INT-MD** (eMbed Data) mode applied to Synthetic or probe packets allows 
+functionality similar to **IFA**[^IFA] 
+
+It is likely that sytnetic traffic created by cloning would be discraded at the Sink,
+while Probe packets might be marked for forwatrding or discarding, depending on the
+use-case. It is the responsibility of the INT-Source node to mark packets correctly 
+to determine if the INT-Sink will forward or discard packets after extracting the 
+INT Data colected along the path. 
 
 
 
@@ -443,16 +446,6 @@ Details of the metadata semantics YANG model can be accessed at the link below:
 
 https://github.com/p4lang/p4-applications/blob/master/telemetry/code/models/p4-dtel-metadata-semantics.yang
 
-* Buffer occupancy
-  - The build-up of traffic in the buffer (in bytes, cells, or packets) that the
-INT packet observes in the device while being forwarded. Use case is when the buffer 
-is shared between multiple queues. The format of this 4-octet metadata field is switch 
-implementation specific and the metadata semantics YANG model shall describe the format 
-and units of this metadata field in the metadata stack.
-
-Details of the metadata semantics YANG model can be accessed at the link below:
-
-https://github.com/p4lang/p4-applications/blob/master/telemetry/code/models/p4-dtel-metadata-semantics.yang
 
 # INT Headers
 
@@ -898,7 +891,7 @@ INT Metadata Header and Metadata Stack:
     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |Ver = 2|Rep|C|E|M|      Reserved     | Hop ML  |RemainingHopCnt|
+   |Ver = 2|Res|C|E|M|      Reserved     | Hop ML  |RemainingHopCnt|
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
    |      Instruction Bitmap       |        Domain Specific ID     |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -912,7 +905,7 @@ INT Metadata Header and Metadata Stack:
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 `
 
-* INT metadata header is 8 bytes long followed by a stack of INT metadata.
+* INT metadata header is 12 bytes long followed by a stack of INT metadata.
   Each metadata is either 4 bytes or 8 bytes in length. Each INT hop adds
   the same length of metadata. The total length of the metadata stack is
   variable as different packets may traverse different paths and hence
@@ -920,30 +913,8 @@ INT Metadata Header and Metadata Stack:
 
 * The fields in the INT metadata header are interpreted the following way:
   - Ver (4b): INT metadata header version. Should be 2 for this version.
-  - Rep (2b): Replication requested. Support for this request is optional. If
-this value is non-zero, the device may replicate the INT packet. This is useful
-to explore all the valid physical forwarding paths when multi-path forwarding
-techniques (e.g., ECMP, LAG) are used in the network. Note the Rep bits should
-be used judiciously (e.g., only for probe packets, not for every data packet).
-While we recommend that Rep bits be set only for probe packets, the INT
-architecture does not (and perhaps cannot) disallow use of the Rep bits for real
-data packets.
-    - 0: No replication requested.
-    - 1: Port-level (L2-level) replication requested. If the INT packet is
-forwarded through a logical port that is a port-channel (LAG), then replicate
-the packet on each physical port in the port-channel and send a single copy per
-physical port.
-    - 2: Next-hop-level (L3-level) replication requested. Forward the packet
-to each L3 ECMP next-hop valid for the destination address, with INT headers
-replicated in each forwarded copy.
-    - 3: Port-level and Next-hop-level replication requested.
-  - C (1b): Copy.
-    - If replication is requested for data packets, the INT Sink must be
-able to distinguish the original packet from replicas so that it can forward
-only original packets up the protocol stack, and drop all the replicas. The C
-bit must be set to 1 on each copy, whenever an INT hop replicates a packet.
-The original packet must have C bit set to 0.
-    - C bit must be set to 0 in the original packet by INT source
+  - Res (2b): Reserved
+  - C   (1b): Copy/Clone. INT Sink should Discard the packet after Extracting INT data 
   - E (1b): Max Hop Count exceeded.
     - This flag must be set if a device cannot prepend its own metadata due to
       the Remaining Hop Count reaching zero.
@@ -999,6 +970,7 @@ each bit corresponds to a specific standard metadata as specified in Section 3.
   - bit6: Level 2 Ingress Port ID + Egress Port ID (4 bytes each)
   - bit7: Egress port Tx utilization
   - bit8: Buffer ID (8 bits) + Buffer occupancy (24 bits)
+  - bit14: Domain Specific Instructions
   - bit15: Checksum Complement
   - The remaining bits are reserved.
   
@@ -1012,7 +984,7 @@ each bit corresponds to a specific standard metadata as specified in Section 3.
   Bits 0 - 13 are Baseline INT Instructions and Bit 14, Domain Specific Instruction.
   Domain Specific Instruction is an instruction that requires additional 
   processing of Domain Specific ID, Domain Specific Flags (DS Flags) and 
-  Domain Specific Field (DS Field). If the Domain Specific ID doesn't match the 
+  Domain Specific Field (DS Instructions Field). If the Domain Specific ID doesn't match the 
   Domain ID of the node, then the transit node is required to pad the node's 
   INT Metadata stack with the special all-ones reserved value for Domain Specific 
   Metadata length as calculated by subtracting the Baseline Metadata Length from Hop_ML.
@@ -1026,7 +998,9 @@ each bit corresponds to a specific standard metadata as specified in Section 3.
   except if bit 6 and bit 14 is set. If bit 6 is set, the instruction requires 
   8 bytes of metadata. If bit 14 is set, the instruction requires a domain specific
   metadata of n bytes, n being a multiple of 4 bytes. Per-hop metadata length is 
-  set accordingly at the INT source.
+  set accordingly at the INT source. Note an INT-Transit node for Non-Domain-Specific
+  mdoe may add Domain-specific INT fields (ID, Instructions and flags) serving in effect
+  as the INT-Source for the Domain-specific functionality. 
 
 * Each INT Transit device along the path that supports INT adds its own metadata
 values as specified in the instruction bitmap immediately after the INT metadata
@@ -1067,11 +1041,12 @@ header.
     metadata header.
 * Summary of the field usage
   - The INT Source must set the following fields:
-    - Ver, Rep, C, M, Per-hop Metadata Length, Remaining Hop Count,
+    - Ver, C, M, Per-hop Metadata Length, Remaining Hop Count,
       and Instruction Bitmap.
     - INT Source must set all reserved bits to zero.
+    - INt Source may set the Domain-specific fileds. 
   - Intermediate devices can set the following fields:
-    - C, E, M, Remaining Hop Count
+    - C, E, M, Remaining Hop Count, Domain-specific fields
 * The length (in bytes) of the INT metadata stack must always
 be a multiple of (Per-hop Metadata Length \* 4). This length can be determined
 by subtracting the total INT fixed header sizes (12 bytes)
@@ -1104,7 +1079,6 @@ port ID)
 * The maximum number of hops (network diameter) is 8.
 * The values of INT metadata header fields in this example are as follows:
   - Ver = 1
-  - Rep = 0 (No replication)
   - C = 0
   - E = 0 (Max Hop Count not exceeded)
   - M = 0 (MTU not exceeded at any switch)
@@ -1165,7 +1139,7 @@ INT Shim Header for TCP/UDP, INT type is hop-by-hop:
     0                   1                   2                   3
     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |     Type=1    |   Reserved    |  Length = 8   |   DSCP    |R R|
+   |     Type=1    |   Reserved    |  Length = 7   |   DSCP    |R R|
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 `
 
@@ -1281,7 +1255,7 @@ Geneve Option for INT, hop-by-hop type:
     0                   1                   2                   3
     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-   |      Option Class=0x00AB      |     Type=1    |R|R|R|  Len=8  |
+   |      Option Class=0x00AB      |     Type=1    |R|R|R|  Len=9  |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 `
 


### PR DESCRIPTION
- Removed "Rep" 
- Removed special "Synthetic/Probe sections";  replaced with clarification of using C bit for such traffic 
- Allow Transit nodes to do OAM generation and NW Event Detection
- Allow Transit nodes to be INT Source for the Domain-specific parts 
- Some minor cleanup, length fixes in examples, etc.